### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "Python"

--- a/README.MD
+++ b/README.MD
@@ -9,3 +9,4 @@ Installation of python if not already installed ->
 1) google python 3.6
 2) Download the installer.
 3) After completion, run pacman.py using python shell.
+[![Run on Repl.it](https://repl.it/badge/github/Prakhar-FF13/Pacman-game-using-Python)](https://repl.it/github/Prakhar-FF13/Pacman-game-using-Python)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ColeFranz/Pacman-game-using-Python-1).